### PR TITLE
Added supporting of the endpoints: /item/get, /item/delete, /item/acc…

### DIFF
--- a/src/api/AccessToken.php
+++ b/src/api/AccessToken.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Plaid\Api;
+
+class AccessToken extends Api
+{
+    public function __construct($client)
+    {
+        parent::__construct($client);
+    }
+
+    public function invalidate($accessToken)
+    {
+        return $this->client()->post('/item/access_token/invalidate', [
+            'access_token' => $accessToken
+        ]);
+    }
+
+    public function updateVersion($accessToken)
+    {
+        return $this->client()->post('/item/access_token/update_version', [
+            'access_token' => $accessToken
+        ]);
+    }
+}

--- a/src/api/Item.php
+++ b/src/api/Item.php
@@ -4,15 +4,45 @@ namespace Plaid\Api;
 
 class Item extends Api
 {
+    /**
+     * @var PublicToken
+     */
+    protected $publicToken;
+
+    /**
+     * @var AccessToken
+     */
+    protected $accessToken;
+
     public function __construct($client)
     {
         parent::__construct($client);
 
         $this->publicToken = new PublicToken($client);
+        $this->accessToken = new AccessToken($client);
     }
 
     public function publicToken()
     {
         return $this->publicToken;
+    }
+
+    public function accessToken()
+    {
+        return $this->accessToken;
+    }
+
+    public function get($accessToken)
+    {
+        return $this->client()->post('/item/get', [
+            'access_token' => $accessToken
+        ]);
+    }
+
+    public function delete($accessToken)
+    {
+        return $this->client()->post('/item/delete', [
+            'access_token' => $accessToken
+        ]);
     }
 }


### PR DESCRIPTION
Added supporting of the endpoints: 
/item/get, /item/delete (in Item), 
/item/access_token/invalidate, /item/access_token/update_version (in AccessToken).

Please merge these changes, it's needed for my Quickstart app 
(it will be like the original Plaid Quickstart app and I will upload it to GitHub some later).
I think, the community is also waiting for these changes.