### PR TITLE
Asset report features added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # plaid-api-php-client
- 
+
 [![GitHub release](https://img.shields.io/github/release/dpods/plaid-api-php-client.svg)](https://github.com/dpods/plaid-api-php-client) [![GitHub license](https://img.shields.io/github/license/dpods/plaid-api-php-client.svg)](https://github.com/dpods/plaid-api-php-client/blob/master/LICENSE)
- 
+
 PHP Client for the [plaid.com][1] API
 
 This is a PHP port of the official [python client][2] library for the Plaid API
-
 
 ## Table of Contents
 
@@ -14,19 +13,22 @@ This is a PHP port of the official [python client][2] library for the Plaid API
 - [Examples](#examples)
 
 ## Install
+
 ```console
 $ composer require dpods/plaid-api-php-client
 ```
 
 ## Documentation
 
-The module supports only a select few Plaid API endpoints at the moment.  For complete information about
+The module supports only a select few Plaid API endpoints at the moment. For complete information about
 the Plaid.com API, head to the [Plaid Documentation][3].
 
 ## Examples
 
 ### Exchange a public token for an access token
+
 Exchange a `public_token` from [Plaid Link][4] for a Plaid access token:
+
 ```php
 $clientId = '*****';
 $secret = '*****';
@@ -40,16 +42,130 @@ $accessToken = $response['access_token'];
 ```
 
 ### Retrieve Transactions
+
 ```php
 $response = $client->transactions()->get($accessToken, '2018-01-01', '2018-01-31');
 $transactions = $response['transactions'];
 ```
 
+### Asset Reports
+
+There are multiple steps to retrieving an Asset Report.
+
+1. [Create](#create-an-asset-report) the report
+2. [Filter](#filter-an-asset-report) unwanted accounts out of report
+3. [Retrieve](#retrieve-an-asset-report) the report as JSON or PDF
+4. [Refresh](#refresh-an-asset-report) a previously created or filtered report
+5. [Remove](#remove-an-asset-report) a report
+
+## Create an Asset Report
+
+```php
+// an array of previously generated access_tokens
+$accessTokens = ['<access_token(s) returned from exchange token call(s)>'];
+$daysRequested = 180;
+// all of these are optional
+$options = [
+  'client_report_id' => '<user supplied id for reference',
+  'webhook' => 'https://your-application.io/webhook',
+  'user' => [
+    'client_user_id' => '<user supplied id>',
+    'first_name' => 'Testynthia',
+    'middle_name' => 'T.',
+    'last_name' => 'Tertestdez',
+    'ssn' => '123-45-6789',
+    'phone_number' => '555-555-1234',
+    'email' => 'test@test.com'
+  ]
+];
+$response = $this->client->assetReport()->create($accessTokens, $daysRequested, $options);
+```
+
+#### Create Asset Report Response
+
+```json
+{
+  "asset_report_id": "<asset_report guid>",
+  "asset_report_token": "<assets-sandbox-guid>",
+  "request_id": "<request_id>"
+}
+```
+
+### Filter an Asset Report
+
+```php
+$assetReportToken = '<returned in asset report creation call>';
+$accountIdsToExclude = ['<credit_card_id>', '<401k_account_id>'];
+$response = $this->client->assetReport()->filter($assetReportToken, $accountIdsToExclude);
+```
+
+#### Filter Asset Report Repsonse
+
+```json
+{
+  "asset_report_id": "<asset_report guid>",
+  "asset_report_token": "<assets-sandbox-guid>",
+  "request_id": "<request_id>"
+}
+```
+
+### Retrieve an Asset Report
+
+```php
+// retrieve the report in JSON format
+$response = $this->client->assetReport()->get($accessReportToken);
+
+// retrieve the report in PDF format
+$response = $this->client->assetReport()->getPdf($accessReportToken);
+file_put_contents('asset-report.pdf', $response);
+```
+
+#### Retrieve Asset Report Response
+
+The JSON results of an asset report can be reviewed in [plaid's documentation][5].
+
+The /asset_report/pdf/get endpoint returns binary PDF data, which can be saved into a local file.
+
+### Refresh an Asset Report
+
+```php
+// $daysRequested is optional and only needed if you want to override the value sent when report was created
+// $options is optional, only required for overrides to previous values
+$response = $this->client->assetReport()->refresh($assetReportToken, $daysRequested, $options);
+```
+
+#### Refresh Asset Report Response
+
+```json
+{
+  "asset_report_id": "<asset_report guid>",
+  "asset_report_token": "<assets-sandbox-guid>",
+  "request_id": "<request_id>"
+}
+```
+
+### Remove an Asset Report
+
+```php
+$response = $this->client->assetReport()->remove($assetReportToken);
+```
+
+#### Remove Asset Report Response
+
+```json
+{
+  "removed": true,
+  "request_id": "<request_id>"
+}
+```
+
 ## License
-[MIT][5]
+
+[MIT][6]
 
 [1]: https://plaid.com
 [2]: https://github.com/plaid/plaid-python
 [3]: https://plaid.com/docs/api
 [4]: https://github.com/plaid/link
-[5]: https://github.com/dpods/plaid-api-php-client/blob/master/LICENSE
+[5]: https://plaid.com/docs/#assets
+[6]: https://github.com/dpods/plaid-api-php-client/blob/master/LICENSE

--- a/src/Api/AssetReport.php
+++ b/src/Api/AssetReport.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Plaid\Api;
+
+/**
+ * @link https://plaid.com/docs/#assets
+ */
+class AssetReport extends Api
+{
+    /**
+     * Creates an Asset Report with all accounts linked to each Item associated with passed accessTokens.
+     *
+     * @link https://plaid.com/docs/#create-asset-report-request
+     *
+     * @param array $accessTokens An array of access tokens, one token for each Item to be included in the Asset Report.
+     * @param int $daysRequested Days of transaction history requested to be included in the Asset Report.
+     * @param object $options Optional. See docs for list of options.
+     */
+    public function create($accessTokens, $daysRequested, $options = [])
+    {
+        return $this->client()->post('/asset_report/create', [
+            'access_tokens' => $accessTokens,
+            'days_requested' => $daysRequested,
+            'options' => $options,
+        ]);
+    }
+
+    /**
+     * Retrieves an Asset Report that has been previously created.
+     *
+     * @param string $assetReportToken The token returned in create or filter response.
+     * @param bool $includeInsights Requires activation of feature by Plaid.
+     */
+    public function get($assetReportToken, $includeInsights = false)
+    {
+        $data = [
+            'asset_report_token' => $assetReportToken,
+        ];
+
+        if ($includeInsights) {
+            $data['include_insights'] = $includeInsights;
+        }
+
+        return $this->client->post('/asset_report/get', $data);
+    }
+
+    /**
+     * Retrieves an Asset Report that has been previously created.
+     *
+     * @param string $assetReportToken The token returned in create or filter response.
+     * @param bool $includeInsights Requires activation of feature by Plaid.
+     *
+     * @return binary The PDF output to be saved into a file.
+     */
+    public function getPdf($assetReportToken, $includeInsights = false)
+    {
+        $data = [
+            'asset_report_token' => $assetReportToken,
+        ];
+
+        if ($includeInsights) {
+            $data['include_insights'] = $includeInsights;
+        }
+
+        return $this->client->post('/asset_report/pdf/get', $data, false);
+    }
+
+    /**
+     * Create an Asset Report that excludes accounts identified by passed accountIdsToExclude.
+     *
+     * @link https://plaid.com/docs/#specifying-which-accounts-appear-in-the-asset-report
+     *
+     * @param string $assetReportToken The token returned in create request.
+     * @param array $accountIdsToExclude The list of ids to exclude from new report.
+     */
+    public function filter($assetReportToken, $accountIdsToExclude)
+    {
+        return $this->client->post('/asset_report/filter', [
+            'asset_report_token' => $assetReportToken,
+            'account_ids_to_exclude' => $accountIdsToExclude,
+        ]);
+    }
+
+    /**
+     * Refresh a previously created Asset Report.
+     *
+     * @link https://plaid.com/docs/#refreshing-an-asset-report
+     *
+     * @param string $assetReportToken The token returned in create or filter response.
+     * @param int $daysRequested Override the days_requested on previously created/filtered report.
+     * @param array $options Override the options array on previously created/filtered report.
+     */
+    public function refresh($assetReportToken, $daysRequested = null, $options = [])
+    {
+        $data = ['asset_report_token' => $assetReportToken];
+
+        if (!is_null($daysRequested)) {
+            $data['days_requested'] = $daysRequested;
+        }
+
+        if (!empty($options)) {
+            $data['options'] = $options;
+        }
+
+        return $this->client()->post('/asset_report/refresh', $data);
+    }
+
+    /**
+     * Remove a previously created Asset Report.
+     *
+     * @param string $assetReportToken The token returned in create or filter response.
+     */
+    public function remove($assetReportToken)
+    {
+        return $this->client->post('/asset_report/remove', [
+            'asset_report_token' => $assetReportToken,
+        ]);
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace Plaid;
 
 use Plaid\Api\Accounts;
+use Plaid\Api\AssetReport;
 use Plaid\Api\Auth;
 use Plaid\Api\Balance;
 use Plaid\Api\Categories;
@@ -59,6 +60,7 @@ class Client
         $this->requester = new Requester();
 
         $this->accounts = new Accounts($this);
+        $this->assetReport = new AssetReport($this);
         $this->auth = new Auth($this);
         $this->balance = new Balance($this);
         $this->categories = new Categories($this);
@@ -73,6 +75,11 @@ class Client
     public function accounts()
     {
         return $this->accounts;
+    }
+
+    public function assetReport()
+    {
+        return $this->assetReport;
     }
 
     public function auth()
@@ -120,14 +127,14 @@ class Client
         return $this->transactions;
     }
 
-    public function post($path, $data)
+    public function post($path, $data, $autoDecode = true)
     {
         $postData = array_merge($data, [
             'client_id' => $this->clientId,
             'secret' => $this->secret,
         ]);
 
-        return $this->_post($path, $postData);
+        return $this->_post($path, $postData, $autoDecode);
     }
 
     public function postPublic($path, $data)
@@ -144,13 +151,14 @@ class Client
         return $this->_post($path, $postData);
     }
 
-    private function _post($path, $data)
+    private function _post($path, $data, $autoDecode = true)
     {
         return $this->requester()->postRequest(
             implode(['https://', $this->env, '.plaid.com', $path]),
             $data,
             $this->timeout,
-            $this->apiVersion
+            $this->apiVersion,
+            $autoDecode
         );
     }
 

--- a/src/Requester.php
+++ b/src/Requester.php
@@ -4,11 +4,11 @@ namespace Plaid;
 
 class Requester
 {
-    public function postRequest($url, $data, $timeout, $apiVersion = null)
+    public function postRequest($url, $data, $timeout, $apiVersion = null, $autoDecode = true)
     {
         try {
             $jsonResponse = $this->httpRequest('POST', $url, $data, $timeout, $apiVersion);
-            $response = json_decode($jsonResponse, true);
+            $response = ($autoDecode) ? json_decode($jsonResponse, true) : $jsonResponse;
         } catch (\Exception $e) {
             throw PlaidException::fromResponse([
                 'error_message' => $e->getMessage(),
@@ -34,11 +34,11 @@ class Requester
         curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonStr);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
-                'Content-Type: application/json',
-                'Content-Length: ' . strlen($jsonStr),
-                'User-Agent: Plaid PHP v' . Client::VERSION,
-                'Plaid-Version: ' . ($apiVersion ? $apiVersion : Client::DEFAULT_API_VERSION)
-            ]
+            'Content-Type: application/json',
+            'Content-Length: ' . strlen($jsonStr),
+            'User-Agent: Plaid PHP v' . Client::VERSION,
+            'Plaid-Version: ' . ($apiVersion ? $apiVersion : Client::DEFAULT_API_VERSION),
+        ]
         );
 
         $result = curl_exec($ch);


### PR DESCRIPTION
I added an AssetReport class with methods for creating, filtering, getting (json/pdf), refreshing and removing asset reports. 

I did have to make some edits to Client.php and Requester.php to support retrieving the report in pdf format. I tried to make those changes in as sane of a way as possible while also minimizing the actual changes. If you have a different preference for how to incorporate the need to skip automatically json_decode'ing the response I'm all for it. I experimented with a nearly duplicate class method, but it seemed unnecessary. Your call!
